### PR TITLE
Diverged develop to master

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -6,8 +6,11 @@
     "description" : "This module adds several generators for human settlements and roads",
     "dependencies" : [
         {"id" : "Core", "minVersion" : "2.0.0"},
+        {"id" : "NameGenerator","minVersion" : "0.4.0"},
+        {"id" : "Pathfinding", "minVersion" : "0.3.0"},
         {"id" : "Fences", "minVersion" : "0.1.0"},
-        {"id" : "CommonWorld", "minVersion" : "0.2.2"}
+        {"id" : "CommonWorld", "minVersion" : "0.2.2"},
+        {"id" : "StructuralResources", "minVersion" : "1.0.1-SNAPSHOT"}
     ],
     "isServerSideOnly" : false,
     "isGameplay" : "false"


### PR DESCRIPTION
Trying to work my mega module workspace for release prep I noticed a problem in the StaticCities module while having the Cities develop branch checked out (for Light & Shadow etc). Turns out that's because `Parcel` was turned into an interface instead of a class in the master branch here, which hasn't happened in develop yet

Sorting out the conflict in `module`txt should be easy enough, `QuestEntityProvider`, `SimpleBiomeProvider`, and `SurfaceHeightFacetProvider` were deleted and modified at the same time so I've let that happen here